### PR TITLE
add a log to aggregator

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -74,6 +74,7 @@ func (s *AggregatorService) GetCertificate(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operators: %w", err)
 	}
+	s.logger.Info("Number of operators registered", "numOperators", len(operators))
 
 	// Send task to all operators in parallel
 	for operatorId, operator := range operators {


### PR DESCRIPTION
- Sometimes if you forget to register operator the aggregator stops since it doesn't have any operators. adding a log so we can get to know how many operators are registered.